### PR TITLE
Mark optional CRD fields

### DIFF
--- a/pkg/apis/openfaas/v1/types.go
+++ b/pkg/apis/openfaas/v1/types.go
@@ -18,17 +18,26 @@ type Function struct {
 
 // FunctionSpec is the spec for a Function resource
 type FunctionSpec struct {
-	Name                   string             `json:"name"`
-	Image                  string             `json:"image"`
-	Handler                string             `json:"handler"`
-	Annotations            *map[string]string `json:"annotations"`
-	Labels                 *map[string]string `json:"labels"`
-	Environment            *map[string]string `json:"environment"`
-	Constraints            []string           `json:"constraints"`
-	Secrets                []string           `json:"secrets"`
-	Limits                 *FunctionResources `json:"limits"`
-	Requests               *FunctionResources `json:"requests"`
-	ReadOnlyRootFilesystem bool               `json:"readOnlyRootFilesystem"`
+	Name  string `json:"name"`
+	Image string `json:"image"`
+	// +optional
+	Handler string `json:"handler,omitempty"`
+	// +optional
+	Annotations *map[string]string `json:"annotations,omitempty"`
+	// +optional
+	Labels *map[string]string `json:"labels,omitempty"`
+	// +optional
+	Environment *map[string]string `json:"environment,omitempty"`
+	// +optional
+	Constraints []string `json:"constraints,omitempty"`
+	// +optional
+	Secrets []string `json:"secrets,omitempty"`
+	// +optional
+	Limits *FunctionResources `json:"limits,omitempty"`
+	// +optional
+	Requests *FunctionResources `json:"requests,omitempty"`
+	// +optional
+	ReadOnlyRootFilesystem bool `json:"readOnlyRootFilesystem"`
 }
 
 // FunctionResources is used to set CPU and memory limits and requests

--- a/pkg/controller/annotations_test.go
+++ b/pkg/controller/annotations_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Test_makeAnnotations_NoKeys(t *testing.T) {
-	annotationVal := `{"name":"","image":"","handler":"","annotations":null,"labels":null,"environment":null,"constraints":null,"secrets":null,"limits":null,"requests":null,"readOnlyRootFilesystem":false}`
+	annotationVal := `{"name":"","image":"","readOnlyRootFilesystem":false}`
 
 	spec := faasv1.Function{
 		Spec: faasv1.FunctionSpec{},
@@ -36,7 +36,7 @@ func Test_makeAnnotations_NoKeys(t *testing.T) {
 }
 
 func Test_makeAnnotations_WithKeyAndValue(t *testing.T) {
-	annotationVal := `{"name":"","image":"","handler":"","annotations":{"key":"value","key2":"value2"},"labels":null,"environment":null,"constraints":null,"secrets":null,"limits":null,"requests":null,"readOnlyRootFilesystem":false}`
+	annotationVal := `{"name":"","image":"","annotations":{"key":"value","key2":"value2"},"readOnlyRootFilesystem":false}`
 
 	spec := faasv1.Function{
 		Spec: faasv1.FunctionSpec{
@@ -83,7 +83,7 @@ func Test_makeAnnotationsDoesNotModifyOriginalSpec(t *testing.T) {
 	expectedAnnotations := map[string]string{
 		"prometheus.io.scrape": "false",
 		"test.foo":             "bar",
-		annotationFunctionSpec: `{"name":"testfunc","image":"","handler":"","annotations":{"test.foo":"bar"},"labels":null,"environment":null,"constraints":null,"secrets":null,"limits":null,"requests":null,"readOnlyRootFilesystem":false}`,
+		annotationFunctionSpec: `{"name":"testfunc","image":"","annotations":{"test.foo":"bar"},"readOnlyRootFilesystem":false}`,
 	}
 
 	makeAnnotations(function)


### PR DESCRIPTION
## Description

Mark optional CRD fields to fix json deserialisation errors like:

```
Invalid value: "null": spec.constraints in body must be of type array: "null"
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] I have run the [certifier](https://github.com/openfaas/certifier)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
